### PR TITLE
Fix Filters On Project Event Pages

### DIFF
--- a/projects/templates/projects/pages/project_events.html
+++ b/projects/templates/projects/pages/project_events.html
@@ -24,7 +24,7 @@
 
       <div class="row g-3">
         {% for event in child_list_page %}
-          <div class="col-8 col-lg-4">
+          <div class="col-8">
             <article class="p-3 bg-white iscroll_item">
               <div class="mb-3 d-flex flex-direction-column justify-content-between microcopy">
                 <div class="me-2 text-nowrap">


### PR DESCRIPTION
When `project_events.html` passes to the `filters.html` component as tags, `filter_form.theme` lacks `tag.choices`, for some reason. Hence the filters do not appear. Despite running the same code path. Making the conditional on switch on `tags` get it to work as expected. However making this fix causes other uses of the filter to break as they need to deal with different inputs.

Since these filters appear on project event sub-pages and due to the fact that they have they have a different look and feel, it is best for the moment to not use the common component and create a special inlined case. While this increases duplication a little, it's good enough for now.

Also fixes the width of events on desktop while we are poking about!