### PR TITLE
Expose first_published_at to editor on articles

### DIFF
--- a/stopwatch/models/pages.py
+++ b/stopwatch/models/pages.py
@@ -188,6 +188,7 @@ class Article(ListableMixin, StopwatchPage):
         ImageChooserPanel('photo'),
         StreamFieldPanel('summary'),
         StreamFieldPanel('body'),
+        FieldPanel('first_published_at'),
 
         MultiFieldPanel([
             InlinePanel('article_authors'),


### PR DESCRIPTION
Exposes `first_published_at` to editor. This allows older content to be retro-actively added from the legacy site with the correct date.