### PR TITLE
Display people as a single column, when there is only one entry

### DIFF
--- a/stopwatch/models/components.py
+++ b/stopwatch/models/components.py
@@ -149,6 +149,15 @@ class PersonListBlock(StructBlock):
     heading = CharBlock()
     people = ListBlock(SnippetChooserBlock(Person))
 
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context)
+
+        # We want to render differently if just a single person in the list (full-width on desktop-size screens)
+        if len(value['people']) == 1:
+            context['single_person_list'] = True
+
+        return context
+
 
 class OrganisationListBlock(StructBlock):
     class Meta:

--- a/stopwatch/templates/stopwatch/components/person_list.html
+++ b/stopwatch/templates/stopwatch/components/person_list.html
@@ -6,7 +6,7 @@
   <div class="container-fluid">
     <div class="row">
       {% for person in self.people %}
-      <div class="col-4 d-flex flex-column align-items-start mb-5">
+      <div class="col-8 {% if not single_person_list %}col-md-4{% endif %} d-flex flex-column align-items-start mb-5">
         <div class="d-flex flex-row">
           {% if person.photo %}
             <div class="me-2">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Where there is a single person in a person list, display it full-width rather than 50% width colulmns.

For good measure, add a responsive breakpoint to always show full-width on mobile.

## Motivation and Context
Resolves #12

## How Can It Be Tested?
* Add a person list block onto a page with one person. Add a person list block with two people.
* Observe that the first is full-width, but the second is in columns.

## How Will This Be Deployed?
Nothing special here.

## Screenshots (if appropriate):
<img width="807" alt="Screenshot 2022-03-14 at 12 10 45" src="https://user-images.githubusercontent.com/361391/158169417-09bef5f2-2cd8-4528-8ebd-d45189d0b67a.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [x] My code follows the code style of this project.
- [x] I've updated the documentation accordingly.