### PR TITLE
Add shiny to pages

### DIFF
--- a/commonknowledge/wagtail/embed_providers/shiny.py
+++ b/commonknowledge/wagtail/embed_providers/shiny.py
@@ -1,0 +1,55 @@
+
+import re
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+from wagtail.embeds.finders.base import EmbedFinder
+import requests
+
+
+class ShinyFinder(EmbedFinder):
+    SHINY_URL_PATTERN = re.compile(
+        r'https://stop-watch.shinyapps.io/(.+)/?')
+
+    def accept(self, url):
+        """
+        Returns True if this finder knows how to fetch an embed for the URL.
+        This should not have any side effects (no requests to external servers)
+        """
+        return self.SHINY_URL_PATTERN.match(url) is not None
+
+    def find_embed(self, url, max_width=None):
+        """
+        Takes a URL and max width and returns a dictionary of information about the
+        content to be used for embedding it on the site.
+
+        This is the part that may make requests to external APIs.
+        """
+
+        return {
+            'title': "Title of the content",
+            'author_name': "StopWatch",
+            'provider_name': "Shiny",
+            'type': "rich",
+            'width': max_width,
+            'height': None,
+            'thumbnail_url': _ThumbnailExtract.from_page_url(url),
+            'html': f'<iframe src="{url}" width="100%" height="400px"></iframe>'
+        }
+
+
+class _ThumbnailExtract(HTMLParser):
+    image = None
+
+    @staticmethod
+    def from_page_url(url):
+        parser = _ThumbnailExtract()
+        parser.feed(requests.get(url).text)
+
+        return parser.image
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'meta' and self.get_attr(attrs, 'property') == 'og:image':
+            self.image = self.get_attr(attrs, 'content')
+
+    def get_attr(self, attrs, key):
+        return next((val for attrkey, val in attrs if key == attrkey), None)

--- a/commonknowledge/wagtail/embed_providers/shiny.py
+++ b/commonknowledge/wagtail/embed_providers/shiny.py
@@ -4,6 +4,7 @@ from html.parser import HTMLParser
 from urllib.parse import urlparse
 from wagtail.embeds.finders.base import EmbedFinder
 import requests
+from django.utils.text import slugify
 
 
 class ShinyFinder(EmbedFinder):
@@ -33,7 +34,7 @@ class ShinyFinder(EmbedFinder):
             'width': max_width,
             'height': None,
             'thumbnail_url': _ThumbnailExtract.from_page_url(url),
-            'html': f'<iframe src="{url}" width="100%" height="400px"></iframe>'
+            'html': f'<iframe id="shiny-{slugify(url)}" src="{url}"></iframe>'
         }
 
 

--- a/stopwatch/settings/base.py
+++ b/stopwatch/settings/base.py
@@ -214,6 +214,9 @@ WAGTAILEMBEDS_FINDERS = [
         'class': 'commonknowledge.wagtail.embed_providers.flourish.FlourishFinder',
     },
     {
+        'class': 'commonknowledge.wagtail.embed_providers.shiny.ShinyFinder',
+    },
+    {
         'class': 'commonknowledge.wagtail.embed_providers.youtube.YouTubeFinder',
     },
     {

--- a/stopwatch/templates/base.html
+++ b/stopwatch/templates/base.html
@@ -21,7 +21,7 @@
         <script>
             document.documentElement.classList.remove('no-js')
         </script>
-         
+        <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.min.js"></script>
         <meta charset="utf-8" />
         <title>
             {% block title %}
@@ -255,6 +255,7 @@
         <script src="https://unpkg.com/infinite-scroll@4/dist/infinite-scroll.pkgd.min.js"></script>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
         <script src="https://public.flourish.studio/resources/embed.js"></script>
+   
     
         {% block extra_js %}
         {% endblock %}

--- a/stopwatch/templates/stopwatch/components/embed.html
+++ b/stopwatch/templates/stopwatch/components/embed.html
@@ -6,5 +6,5 @@
 </div> 
 
 <script>
-  iFrameResize({ log: true }, '#shiny-{{ self.embed_url | slugify }}')
+  iFrameResize({ log: false }, '#shiny-{{ self.embed_url | slugify }}')
 </script>

--- a/stopwatch/templates/stopwatch/components/embed.html
+++ b/stopwatch/templates/stopwatch/components/embed.html
@@ -1,5 +1,10 @@
 {% load static ckbootstrap_tags wagtailembeds_tags %}
 
+
 <div class="embed{% if self.fullscreen %} embed-fullscreen{% endif %}">
   {% embed self.embed_url %}
-</div>
+</div> 
+
+<script>
+  iFrameResize({ log: true }, '#shiny-{{ self.embed_url | slugify }}')
+</script>


### PR DESCRIPTION

## Description
This PR adds support for embedding Shiny Apps https://shiny.oxshef.io/deploy_embedding-shiny-apps.html in a custom embed finder

- Creates custom embed finder for Shiny Apps
- Renders Shiny App iFrame in embed component
- Adds iFrame re-sizer JavaScript package to display it nicely

## Motivation and Context
Addresses issue #38 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.