### PR TITLE
Infinite Scroll Bug

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,5 +14,8 @@ ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# Install system dependencies
+# Install system dependencies 
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmour -o /usr/share/keyrings/yarn-keyring.gpg \
+  && sed -i '1s;^deb;deb [signed-by=/usr/share/keyrings/yarn-keyring.gpg];' /etc/apt/sources.list.d/yarn.list
 RUN curl https://raw.githubusercontent.com/commonknowledge/do-app-baseimage-django-node/main/.bin/prepare.sh | /bin/bash

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,6 +25,10 @@ services:
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
 
+
+    volumes:
+      - ..:/workspace:cached
+
     # Uncomment the next line to use a non-root user for all processes.
     # user: vscode
 

--- a/commonknowledge/wagtail/models.py
+++ b/commonknowledge/wagtail/models.py
@@ -64,6 +64,7 @@ class ChildListMixin:
         qs = self.get_child_list_queryset(request)
         filter = self.get_filters(request)
         sort = self.get_sort(request)
+        requested_page = safe_to_int(request.GET.get('page'), 1)
 
         if filter:
             if isinstance(filter, dict):
@@ -80,8 +81,11 @@ class ChildListMixin:
         else:
             paginator = Paginator(search, self.get_page_size())
 
-        page = min(paginator.num_pages, max(
-            1, safe_to_int(request.GET.get('page'), 1)))
+        page = min(paginator.num_pages, max(1, requested_page))
+
+        # Stop this function from just returning the first page of results no matter what page was requested
+        if requested_page > page:
+            return {}
 
         if request.GET.get('empty') == '1':
             try:


### PR DESCRIPTION
I think this should do the trick.

- The problem was that `get_pagination_context` was just returning the highest page number, "N" that contains data. So once you request a page number higher than N, it just returns the data in page N. This breaks the infinite-scroll library on the front end.
- I added a check to return an empty response if the requested page goes above N.
- Maybe there is some use case for the previous behaviour, so this would be useful for the author of the code to weigh in on, if possible, before this is deployed