### PR TITLE
Add bootstrap accordion block

### DIFF
--- a/stopwatch/models/components.py
+++ b/stopwatch/models/components.py
@@ -205,7 +205,7 @@ class PersonListBlock(StructBlock):
     class Meta:
         template = 'stopwatch/components/person_list.html'
 
-    heading = CharBlock()
+    heading = CharBlock(required=False)
     people = ListBlock(SnippetChooserBlock(Person))
 
     def get_context(self, value, parent_context=None):
@@ -264,15 +264,17 @@ class AccordionStreamBlock(StreamBlock):
     Accordion content block
     """
     required = True
-    block = StructBlock([
+    richtext = StructBlock([
         ('title', CharBlock(
             label='Title',
         )),
-        ('content', RichTextBlock(
-            label='Content',
-            features=['h1', 'h2', 'h3', 'h4', 'bold',
-                      'italic', 'ol', 'ul', 'hr', 'link', 'document-link', 'image', 'embed', 'blockquote']
+        ('content', RichTextBlock()),
+    ])
+    people = StructBlock([
+        ('title', CharBlock(
+            label='Title',
         )),
+        ('content', PersonListBlock()),
     ])
 
     class Meta:

--- a/stopwatch/models/components.py
+++ b/stopwatch/models/components.py
@@ -259,12 +259,36 @@ class SummaryTextBlock(RichTextBlock):
                 'link', 'document-link', 'blockquote']
 
 
+class AccordionStreamBlock(StreamBlock):
+    """
+    Accordion content block
+    """
+    required = True
+    block = StructBlock([
+        ('title', CharBlock(
+            label='Title',
+        )),
+        ('content', RichTextBlock(
+            label='Content',
+            features=['h1', 'h2', 'h3', 'h4', 'bold',
+                      'italic', 'ol', 'ul', 'hr', 'link', 'document-link', 'image', 'embed', 'blockquote']
+        )),
+    ])
+
+    class Meta:
+        icon = 'folder-open-1'
+        template = 'stopwatch/components/accordion_block.html'
+        label = 'Accordion'
+
+
 TEXT_MODULES = (
     ('text', RichTextBlock(features=['h1', 'h2', 'h3', 'h4', 'bold',
      'italic', 'ol', 'ul', 'hr', 'link', 'document-link', 'image', 'embed', 'blockquote'])),
     # ('quote', PullQuoteBlock()), # NB: there may be historical uses of this, even though it is removed
     ('embed', EmbedBlock()),
     ('downloads', DownloadsBlock()),
+
+
 )
 
 CONTENT_MODULES = TEXT_MODULES + (
@@ -275,7 +299,8 @@ CONTENT_MODULES = TEXT_MODULES + (
     ('person_listing', PersonListBlock()),
     ('organisation_listing', OrganisationListBlock()),
     ('alert', AlertBlock()),
-    ('calendar', CalendarBlock())
+    ('calendar', CalendarBlock()),
+    ('accordion', AccordionStreamBlock())
 )
 
 LANDING_MODULES = CONTENT_MODULES + (

--- a/stopwatch/scss/overrides.scss
+++ b/stopwatch/scss/overrides.scss
@@ -278,3 +278,28 @@ input.btn-check:checked + label.btn {
   background: $lightred;
   border: 1px solid $primary;
 }
+
+/* Bootstrap accordion block */
+.accordion-header {
+  .accordion-block-title {
+    text-decoration: none !important;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    i.bi-chevron-up {
+      display: block;
+    }
+    i.bi-chevron-down {
+      display: none;
+    }
+    &.collapsed {
+      i.bi-chevron-down {
+        display: block;
+      }
+      i.bi-chevron-up {
+        display: none;
+      }
+    }
+  }
+}

--- a/stopwatch/templates/stopwatch/components/accordion_block.html
+++ b/stopwatch/templates/stopwatch/components/accordion_block.html
@@ -1,19 +1,24 @@
-{% load wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
-<div id="accordion-{{ forloop.counter }}" role="tablist" aria-multiselectable="false" class="accordion">
 {% for block in self %}
-  <div class="accordion-item">
-    <div class="accordion-header" role="tab" id="heading-{{ forloop.counter }}">
-      <a class="accordion-button" type="button"
-      data-bs-toggle="collapse" data-bs-target="#collapse-{{ forloop.parentloop.counter }}-{{ forloop.counter }}"  
-      aria-expanded="false" aria-controls="collapse-{{ forloop.parentloop.counter }}-{{ forloop.counter }}">
-        {% include_block block.value.title %}
-        <i class="fa fa-chevron-down"></i>
-      </a>
+{% with block.id|stringformat:"s" as block_id %}
+  <div id="accordion-{{ block_id }}" role="tablist" aria-multiselectable="false" class="accordion">
+  {% for block in self %}
+    <div class="accordion-block">
+      <div class="accordion-header" role="tab" id="heading-{{ block_id }}">
+        <a class="accordion-block-title heading-large mb-3 collapsed" type="button"
+        data-bs-toggle="collapse" data-bs-target="#collapse-{{ forloop.parentloop.counter }}-{{ block_id }}"  
+        aria-expanded="false" aria-controls="collapse-{{ forloop.parentloop.counter }}-{{ block_id }}">
+          {% include_block block.value.title %}
+          <i class="bi bi-chevron-down"></i>
+          <i class="bi bi-chevron-up"></i>
+        </a>
+      </div>
+      <div id="collapse-{{ forloop.parentloop.counter }}-{{ block_id }}" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ block_id }}">
+        <div class="accordion-block-body">{% include_block block.value.content %}</div>
+      </div>
     </div>
-    <div id="collapse-{{ forloop.parentloop.counter }}-{{ forloop.counter }}" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ forloop.counter }}">
-      <div class="accordion-body">{% include_block block.value.content %}</div>
-    </div>
+  {% endfor %}
   </div>
+  {% endwith %}
 {% endfor %}
-</div>

--- a/stopwatch/templates/stopwatch/components/accordion_block.html
+++ b/stopwatch/templates/stopwatch/components/accordion_block.html
@@ -1,0 +1,19 @@
+{% load wagtailcore_tags %}
+
+<div id="accordion-{{ forloop.counter }}" role="tablist" aria-multiselectable="false" class="accordion">
+{% for block in self %}
+  <div class="accordion-item">
+    <div class="accordion-header" role="tab" id="heading-{{ forloop.counter }}">
+      <a class="accordion-button" type="button"
+      data-bs-toggle="collapse" data-bs-target="#collapse-{{ forloop.parentloop.counter }}-{{ forloop.counter }}"  
+      aria-expanded="false" aria-controls="collapse-{{ forloop.parentloop.counter }}-{{ forloop.counter }}">
+        {% include_block block.value.title %}
+        <i class="fa fa-chevron-down"></i>
+      </a>
+    </div>
+    <div id="collapse-{{ forloop.parentloop.counter }}-{{ forloop.counter }}" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ forloop.counter }}">
+      <div class="accordion-body">{% include_block block.value.content %}</div>
+    </div>
+  </div>
+{% endfor %}
+</div>


### PR DESCRIPTION
Fixes STW-27

This adds a custom block with a bootstrap accordion template.

- The block takes a text title and RichTextBlock or PersonListBlock as content
- Takes styling from the site theme

[Screencast from 2023-02-09 10-32-24.webm](https://user-images.githubusercontent.com/4164774/217774158-3e692d83-3fe2-41aa-8a8f-fc1c5e8cdaab.webm)
