### PR TITLE
Fix for issue with articles tags not displaying

### DIFF
--- a/stopwatch/models/pages.py
+++ b/stopwatch/models/pages.py
@@ -334,7 +334,6 @@ class Category(ExploreTagsMixin, ListableMixin, ChildListMixin, StopwatchPage):
     def get_page_size(self):
         return 25
 
-    @django_cached('stopwatch.models.Category.tags', lambda category: category.get_parent().id)
     def tags(self):
         '''
         Return all tags that apply to articles in this category

--- a/stopwatch/scss/components.scss
+++ b/stopwatch/scss/components.scss
@@ -317,6 +317,12 @@
   border-bottom: 1px solid $primary;
 }
 
+.form-control {
+  @include media-breakpoint-down(md) {
+    margin-top: 20px;
+  }
+}
+
 .filter-ctl {
   @include media-breakpoint-down(md) {
     padding: $btn-padding-x-sm $btn-padding-y-sm;

--- a/stopwatch/templates/stopwatch/includes/filters.html
+++ b/stopwatch/templates/stopwatch/includes/filters.html
@@ -5,14 +5,6 @@
   method="GET"
   class="col-8 form-unraised d-flex flex-row align-items-md-start {% if style == 'ROWS' %}col-md-3 col-lg-2 flex-column{% endif %} {{class}}"
 >
-
-    <div class="me-2 mb-2 mb-md-4">
-      <label class="microcopy mb-1" for="tag_filter">Filter</label>
-      <div id="tag_filter" role="radiogroup" class="overflow-auto-md-column align-items-start">
-        {% filter_toggles field=tags label_class="btn filter-ctl" %}
-      </div>
-    </div>
-
   {% if style == 'GRID' %}
   <span class="flex-grow-1 d-none d-md-block"></span>
   {% endif %}
@@ -30,5 +22,11 @@
         <input class="form-control width-md-auto text-naturalcase filter-ctl" aria-label="Search" autocapitalize="off" name="query" id="search" placeholder="Search" value="{{filter_form.query.value|default:""}}">    
       </div>
     {% endif %}
+  </div>
+  <div class="me-2 mb-2 mb-md-4">
+    <label class="microcopy mb-1" for="tag_filter">Filter</label>
+    <div id="tag_filter" role="radiogroup" class="overflow-auto-md-column d-flex flex-wrap align-items-start gap-2">
+      {% filter_toggles field=tags label_class="btn filter-ctl" %}
+    </div>
   </div>
 </form>

--- a/stopwatch/templates/stopwatch/includes/filters.html
+++ b/stopwatch/templates/stopwatch/includes/filters.html
@@ -5,14 +5,13 @@
   method="GET"
   class="col-8 form-unraised d-flex flex-row align-items-md-start {% if style == 'ROWS' %}col-md-3 col-lg-2 flex-column{% endif %} {{class}}"
 >
-  {% if tags.choices %}
-    <div class="me-2 mb-2mb-md-4">
+
+    <div class="me-2 mb-2 mb-md-4">
       <label class="microcopy mb-1" for="tag_filter">Filter</label>
       <div id="tag_filter" role="radiogroup" class="overflow-auto-md-column align-items-start">
         {% filter_toggles field=tags label_class="btn filter-ctl" %}
       </div>
     </div>
-  {% endif %}
 
   {% if style == 'GRID' %}
   <span class="flex-grow-1 d-none d-md-block"></span>


### PR DESCRIPTION
## Description
This PR removes an if statement and caching that was preventing tags displaying on category pages. 
Also puts the tags below under the search bar as per Habib's request and makes some css tweaks

## Motivation and Context
Addresses issue [STW-35](https://linear.app/commonknowledge/issue/STW-35/filter-by-tags)

## How Will This Be Deployed?
Through automatic deployment on DigitalOcean

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
