### PR TITLE
Iteration on custom aging pages report

### DIFF
--- a/stopwatch/forms.py
+++ b/stopwatch/forms.py
@@ -2,6 +2,8 @@ from commonknowledge.wagtail.models import SortOption
 from stopwatch.models.pages import Category
 from django_bootstrap5.widgets import RadioSelectButtonGroup
 from django import forms
+from django.contrib.contenttypes.models import ContentType
+from wagtail.models import Page
 
 
 class RadioSelectButton(forms.RadioSelect):
@@ -25,3 +27,38 @@ class CategoryFilterForm(forms.Form):
             (tag.slug, tag.name)
             for tag in tags
         )
+
+
+class AgingPagesFilterForm(forms.Form):
+  
+    last_updated_before = forms.DateField(
+        required=False,
+       widget=forms.DateInput(
+            attrs={
+                'type': 'date',
+            }
+        ),
+        label="Last Updated Before",
+    )
+    status = forms.ChoiceField(
+        required=False,
+        choices=[
+            ('', 'All'),
+            ('live', 'Live'),
+            ('draft', 'Draft'),
+        ],
+        label="Status",
+    )
+    page_type = forms.ChoiceField(
+        required=False,
+        choices=[], 
+        label="Page Type",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        content_types = ContentType.objects.filter(id__in=Page.objects.values('content_type_id')).distinct()
+        self.fields['page_type'].choices = [('', 'All')] + [
+            (ct.model, ct.name.capitalize()) for ct in content_types
+        ]

--- a/stopwatch/templates/reports/custom_aging_pages_report.html
+++ b/stopwatch/templates/reports/custom_aging_pages_report.html
@@ -1,0 +1,50 @@
+{% extends "wagtailadmin/base.html" %}
+{% load render_bundle from webpack_loader %}
+
+{% block content %}
+{% render_bundle 'admin' 'js' %}
+
+<div class="report">
+    <h1>{{ view.page_title }}</h1>
+<div class="table-and-form-wrapper">
+    <form method="get" class="filters">
+        {{ filter_form.as_p }}
+        <div class="buttons-wrapper">
+        <button type="submit"  class="button">Apply Filters</button>
+        <a href="{% url view.index_url_name %}" class="button">Clear Filters</a>
+    </div>
+    </form>
+
+    <div class="actions" >
+        <a href="?export=csv&{{ request.GET.urlencode }}" class="button">Export as CSV</a>
+        <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button">Export as Excel</a>
+    </div>
+</div>
+    <table>
+        <thead>
+            <tr>
+                <th style="text-align: left;">Title</th>
+                <th style="text-align: left;">First Published</th>
+                <th style="text-align: left;">Last Updated</th>
+                <th style="text-align: left;">Updated By</th>
+                <th style="text-align: left;">Status</th>
+                <th style="text-align: left;">Page Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for page in annotated_pages %}
+            <tr>
+                <td>
+                    <a href="{{ page.edit_url }}" target="_blank">{{ page.title }}</a>
+                </td>
+                <td>{{ page.first_published_at|date:"d F Y" }}</td>                
+                <td>{{ page.last_updated_at|date:"d F Y"  }}</td>
+                <td>{{ page.updated_by }}</td>
+                <td>{{ page.status }}</td>
+                <td>{{ page.page_type }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/stopwatch/templates/reports/custom_aging_pages_report.html
+++ b/stopwatch/templates/reports/custom_aging_pages_report.html
@@ -1,50 +1,85 @@
 {% extends "wagtailadmin/base.html" %}
-{% load render_bundle from webpack_loader %}
 
 {% block content %}
-{% render_bundle 'admin' 'js' %}
 
-<div class="report">
-    <h1>{{ view.page_title }}</h1>
-<div class="table-and-form-wrapper">
-    <form method="get" class="filters">
-        {{ filter_form.as_p }}
-        <div class="buttons-wrapper">
-        <button type="submit"  class="button">Apply Filters</button>
-        <a href="{% url view.index_url_name %}" class="button">Clear Filters</a>
-    </div>
-    </form>
 
-    <div class="actions" >
-        <a href="?export=csv&{{ request.GET.urlencode }}" class="button">Export as CSV</a>
-        <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button">Export as Excel</a>
+<style>
+    .report {
+        padding: 30px;
+    }
+    
+    form {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        margin-bottom: 10px;
+    }
+    
+    label {
+        margin-right: 5px;
+    }
+    
+    th {
+        text-align: left;
+    }
+    
+    .buttons-wrapper {
+        display: flex;
+    }
+    
+    .table-and-form-wrapper {
+        margin-bottom: 30px;
+    }
+    
+    @media (min-width: 768px) {
+        .table-and-form-wrapper {
+            display: flex;
+            justify-content: space-between;
+        }
+    }
+    </style>
+    
+    <div class="report">
+        <h1>{{ view.page_title }}</h1>
+        <div class="table-and-form-wrapper">
+            <form method="get" class="filters">
+                {{ filter_form.as_p }}
+                <div class="buttons-wrapper">
+                    <button type="submit" class="button">Apply Filters</button>
+                    <a href="{% url view.index_url_name %}" class="button">Clear Filters</a>
+                </div>
+            </form>
+    
+            <div class="actions">
+                <a href="?export=csv&{{ request.GET.urlencode }}" class="button">Export as CSV</a>
+                <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button">Export as Excel</a>
+            </div>
+        </div>
+        <table>
+            <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>First Published</th>
+                    <th>Last Updated</th>
+                    <th>Updated By</th>
+                    <th>Status</th>
+                    <th>Page Type</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for page in annotated_pages %}
+                <tr>
+                    <td>
+                        <a href="{{ page.edit_url }}" target="_blank">{{ page.title }}</a>
+                    </td>
+                    <td>{{ page.first_published_at|date:"d F Y" }}</td>
+                    <td>{{ page.last_updated_at|date:"d F Y" }}</td>
+                    <td>{{ page.updated_by }}</td>
+                    <td>{{ page.status }}</td>
+                    <td>{{ page.page_type }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
-</div>
-    <table>
-        <thead>
-            <tr>
-                <th style="text-align: left;">Title</th>
-                <th style="text-align: left;">First Published</th>
-                <th style="text-align: left;">Last Updated</th>
-                <th style="text-align: left;">Updated By</th>
-                <th style="text-align: left;">Status</th>
-                <th style="text-align: left;">Page Type</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for page in annotated_pages %}
-            <tr>
-                <td>
-                    <a href="{{ page.edit_url }}" target="_blank">{{ page.title }}</a>
-                </td>
-                <td>{{ page.first_published_at|date:"d F Y" }}</td>                
-                <td>{{ page.last_updated_at|date:"d F Y"  }}</td>
-                <td>{{ page.updated_by }}</td>
-                <td>{{ page.status }}</td>
-                <td>{{ page.page_type }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-</div>
-{% endblock %}
+    {% endblock %}

--- a/stopwatch/views.py
+++ b/stopwatch/views.py
@@ -5,93 +5,171 @@ import csv
 import openpyxl
 from django.utils import timezone
 from datetime import timedelta
+from stopwatch.forms import AgingPagesFilterForm
+from wagtail.models import Page
+from django.urls import reverse
 
+from wagtail.models import Page
+from django.utils.timezone import make_naive
 
 
 class CustomAgingPagesReportView(PageReportView):
-    index_url_name = "custom_aging_pages_report"
-    index_results_url_name = "custom_aging_pages_report_results"
-    header_icon = 'time'
-    page_title = "Custom aging pages report"
-
-    export_headings = dict(
-        page_title='Page Title',
-        first_published_at='First Published at',
-        last_updated_at='Last Updated At',
-        live='Status',
-        content_type='Type',
-    )
-
-    def get_queryset(self):
-        # Fetch pages older than 3 years
-        three_years_ago = timezone.now() - timedelta(days=3 * 365)
-        queryset = Page.objects.filter(first_published_at__lte=three_years_ago).order_by('-first_published_at')
-        return queryset
-    
-    
-    # Custom spreadsheet export set up
-    def export_to_csv(self):
-        queryset = self.get_queryset()  
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename="custom_aging_pages_report.csv"'
-
-        writer = csv.writer(response)
-        writer.writerow(self.export_headings.values())
-
-        for page in queryset:
-            row = [
-                page.title,
-                page.first_published_at,
-                self.format_datetime(page.latest_revision_created_at),
-                'Live' if page.live else 'Draft',
-                page.specific_class.__name__,
-            ]
-            writer.writerow(row)
-
-        return response
-
-    def export_to_xlsx(self):
-        queryset = self.get_queryset()  
-
-        workbook = openpyxl.Workbook()
-        sheet = workbook.active
-        sheet.title = "Custom Aging Pages"
-
-        headers = list(self.export_headings.values())
-        sheet.append(headers)
-
-        for page in queryset:
-            row = [
-                page.title,
-                page.first_published_at,
-                self.format_datetime(page.latest_revision_created_at),
-                'Live' if page.live else 'Draft',
-                page.specific_class.__name__,
-            ]
-            sheet.append(row)
-
-        response = HttpResponse(
-            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        template_name = "reports/custom_aging_pages_report.html"
+        model = Page  
+        index_url_name = "custom_aging_pages_report"
+        index_results_url_name = "custom_aging_pages_report_results"
+        header_icon = 'time'
+        page_title = "Custom Aging Pages Report"
+        export_headings = dict(
+            page_title='Page Title',
+            first_published_at='First Published At',
+            last_updated_at='Last Updated At',
+            status='Status',
+            page_type='Page Type', 
         )
-        response['Content-Disposition'] = 'attachment; filename="custom_aging_pages_report.xlsx"'
 
-        workbook.save(response)
-        return response
+        def get_queryset(self):
+            queryset = self.model.objects.all()
+            # Apply the aging filter (pages older than 3 years)
+            three_years_ago = timezone.now() - timedelta(days=3 * 365)
+            queryset = queryset.filter(first_published_at__lte=three_years_ago)
 
-    def dispatch(self, request, *args, **kwargs):
-        export_format = request.GET.get('format', 'csv')
-        if 'export' in request.GET:
-            if export_format == 'xlsx':
-                return self.export_to_xlsx()
-            else:
-                return self.export_to_csv()
-        return super().dispatch(request, *args, **kwargs)
+            last_updated_before = self.request.GET.get('last_updated_before')
+            status = self.request.GET.get('status')
+            page_type = self.request.GET.get('page_type')
 
-    def format_datetime(self, datetime_obj):
-        """
-        Format the datetime object to 'Y-m-d H:i:s' format.
-        Returns an empty string if datetime_obj is None.
-        """
-        if datetime_obj:
-            return datetime_obj.strftime('%Y-%m-%d %H:%M:%S')
-        return ''
+            # Apply date filters
+            if last_updated_before:
+                queryset = queryset.filter(last_published_at__lte=last_updated_before)
+
+            # Apply status filter
+            if status == 'live':
+                queryset = queryset.filter(live=True)
+            elif status == 'draft':
+                queryset = queryset.filter(live=False)
+
+            # Apply page type filter
+            if page_type:
+                queryset = queryset.filter(content_type__model__icontains=page_type)
+
+            return queryset
+
+
+        def format_status(self, page):
+            """Return the status of the page."""
+            if page.live:
+                if page.has_unpublished_changes:
+                    return "Live + Draft"
+                return "Live"
+            return "Draft"
+
+        def format_page_type(self, page):
+            """Return the specific type of the page."""
+            return page.specific_class.__name__
+
+        
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+
+            annotated_data = []
+            for page in self.get_queryset():
+                last_updated_user = (
+                    page.latest_revision.user
+                    if page.latest_revision and page.latest_revision.user
+                    else "Unknown"
+                )
+
+                annotated_data.append({
+                    'title': page.title,
+                    'edit_url': reverse('wagtailadmin_pages:edit', args=[page.id]),
+                    'first_published_at': page.first_published_at,
+                    'last_updated_at': page.latest_revision_created_at,
+                    'updated_by': last_updated_user,  
+                    'status': self.format_status(page),
+                    'page_type': self.format_page_type(page),
+                })
+
+            context['annotated_pages'] = annotated_data
+            context['filter_form'] = AgingPagesFilterForm(self.request.GET)
+            return context
+            
+        def format_status(self, page):
+                """Return the status of the page."""
+                if page.live:
+                    if page.has_unpublished_changes:
+                        return "Live + Draft"
+                    return "Live"
+                return "Draft"
+
+        def export_to_csv(self):
+                queryset = self.get_queryset()
+                response = HttpResponse(content_type='text/csv')
+                response['Content-Disposition'] = 'attachment; filename="custom_aging_pages_report.csv"'
+
+                writer = csv.writer(response)
+                writer.writerow(self.export_headings.values())
+
+                for page in queryset:
+                    row = [
+                        page.title,
+                        self.format_datetime(page.first_published_at),
+                        self.format_datetime(page.latest_revision_created_at),
+                        self.format_status(page),
+                        self.format_page_type(page),  
+                    ]
+                    writer.writerow(row)
+
+                return response
+
+        def export_to_xlsx(self):
+                queryset = self.get_queryset()
+
+                workbook = openpyxl.Workbook()
+                sheet = workbook.active
+                sheet.title = "Custom Aging Pages"
+
+                headers = list(self.export_headings.values())
+                sheet.append(headers)
+
+                for page in queryset:
+                    # Convert datetime fields to naive
+                    first_published_at = page.first_published_at
+                    latest_revision_created_at = page.latest_revision_created_at
+
+                    if first_published_at:
+                        first_published_at = make_naive(first_published_at)
+
+                    if latest_revision_created_at:
+                        latest_revision_created_at = make_naive(latest_revision_created_at)
+
+                    row = [
+                        page.title,
+                        first_published_at,
+                        self.latest_revision_created_at,
+                        self.format_status(page),
+                        self.format_page_type(page),
+                    ]
+                    sheet.append(row)
+
+                response = HttpResponse(
+                    content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+                )
+                response['Content-Disposition'] = 'attachment; filename="custom_aging_pages_report.xlsx"'
+
+                workbook.save(response)
+                return response
+                    
+        def dispatch(self, request, *args, **kwargs):
+                export_format = request.GET.get('export')
+                if export_format == 'csv':
+                    return self.export_to_csv()
+                elif export_format == 'xlsx':
+                    return self.export_to_xlsx()
+
+                return super().dispatch(request, *args, **kwargs)
+            
+        def format_datetime(self, datetime_obj):
+                """Format the datetime object to 'd F Y' format."""
+                if datetime_obj:
+                        return datetime_obj.strftime('%d %B %Y')  
+                return ''


### PR DESCRIPTION
## Description
This PR adds the following:
a custom page template to display the custom aging pages report that was already added
adds filters to the report page to allow users to display and export pages based on last updated date

## Motivation and Context
Addresses issue [STW-57](https://linear.app/commonknowledge/issue/STW-57/customise-wagtails-aging-logic-to-archive-pages-by-their-first) and specifically [this comment](https://linear.app/commonknowledge/issue/STW-57/customise-wagtails-aging-logic-to-archive-pages-by-their-first#comment-1901d4ce) 

## How Can It Be Tested?
Can be tested on staging site https://stopwatch-05nu.onrender.com/admin
If necessary create an admin user by going to the [Render shell](https://dashboard.render.com/web/srv-cque823v2p9s73d6jfqg/shell) and running pipenv run python manage.py createsuperuser 
Go to https://stopwatch-05nu.onrender.com/admin/reports/custom-aging-pages/
Try the spreadsheet download

## How Will This Be Deployed?
Normal CD process

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
