### PR TITLE
COLLAB-5267: normalise front page banner images

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,6 @@ This is based on the experience of @freemvmt trying to set up the project on [Ea
 
 2. Once inside the container, `install.sh` was failing due to multiple copies of `virtualenv` being available. I fixed this by changing all references of `pipenv` to `python -m pipenv`, to ensure that we use the version associated with the python installation (merged in via #[86](https://github.com/commonknowledge/stopwatch/pull/86)).
 
-3. The 'import' option in Wagtail admin dashboard only appeared after populating the `stopwatch/settings/local.py` file. Even then, the import function proved error prone, so we instead used a psql dump from staging to produce a relevant dev environment (i.e. I ran something like `PGPASSWORD=postgres psql -h db -U postgres -d postgres < /workspace/stopwatch_staging.psql`).
+3. The 'import' option in Wagtail admin dashboard only appeared after populating the `stopwatch/settings/local.py` file. Even then, the import function proved error prone, so we instead used a psql dump from staging to produce a relevant dev environment (i.e. I ran something like `PGPASSWORD=postgres psql -h db -U postgres -d postgres < /workspace/stopwatch_staging.psql`) - note that you'll need to manually install `postgresql` in the devcontainer beforehand.
 
 4. The dev site was not initially styled, despite the webpack server that runs as part of the 'App' config in `launch.json` - I ran `yarn webpack` manually to fix that.

--- a/stopwatch/scss/components.scss
+++ b/stopwatch/scss/components.scss
@@ -253,6 +253,21 @@
   background-color: $lightgrey;
 }
 
+// ensure that landing page banner images have a max size (consistent with .img-homepage-hero)
+#content .tab-pane .row > a:has(img) {
+  max-height: 300px;
+  overflow: hidden;
+
+  @include media-breakpoint-up(md) {
+    max-height: 400px;
+  }
+
+  // if an image is cropped we show the top-most part
+  img {
+    object-position: top;
+  }
+}
+
 .btn-wide {
   @include media-breakpoint-up(md) {
     padding-left: 113px;


### PR DESCRIPTION
As per title - see [ticket](https://linear.app/commonknowledge/issue/COLLAB-5267/normalise-front-page-banner-images).

Considers both desktop and mobile views.

## Screenshots (if appropriate):

**Before**

<img width="1119" height="865" alt="image" src="https://github.com/user-attachments/assets/fb9199ed-09e5-4b7b-807b-342681414fe8" />

**After**

<img width="1119" height="450" alt="Screenshot From 2026-04-24 18-08-29" src="https://github.com/user-attachments/assets/9184dcbd-554d-4cd7-b2d6-fb136480433c" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.